### PR TITLE
Add initial ERP models and migration

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,64 @@
+"""Alembic environment configuration."""
+
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.core.config import get_settings
+from app.db.base import Base
+
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def get_url() -> str:
+    return get_settings().database_url
+
+
+def run_migrations_offline() -> None:
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section)
+    if configuration is None:
+        configuration = {}
+    configuration["sqlalchemy.url"] = get_url()
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+

--- a/alembic/versions/0001_create_all_initial_tables.py
+++ b/alembic/versions/0001_create_all_initial_tables.py
@@ -1,0 +1,244 @@
+"""create all initial tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "organizations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("slug", sa.String(length=50), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("slug", name="uq_organizations_slug"),
+    )
+
+    op.create_table(
+        "roles",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("permissions", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("hashed_password", sa.String(length=255), nullable=False),
+        sa.Column("first_name", sa.String(length=100), nullable=True),
+        sa.Column("last_name", sa.String(length=100), nullable=True),
+        sa.Column("role_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("is_active", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"]),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+    )
+
+    op.create_table(
+        "partners",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("type", sa.String(length=50), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.CheckConstraint("type IN ('CUSTOMER','SUPPLIER','BOTH')", name="ck_partners_type"),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("email", name="uq_partners_email"),
+    )
+
+    op.create_table(
+        "materials",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("stock_quantity", sa.Numeric(10, 2), server_default="0", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "products",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("base_price_sqm", sa.Numeric(10, 2), server_default="0", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "orders",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("partner_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("total_amount", sa.Numeric(10, 2), server_default="0", nullable=False),
+        sa.Column("tax_amount", sa.Numeric(10, 2), server_default="0", nullable=False),
+        sa.Column("grand_total", sa.Numeric(10, 2), server_default="0", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.CheckConstraint(
+            "status IN ('TEKLIF','SIPARIS','URETIMDE')",
+            name="ck_orders_status",
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["partner_id"], ["partners.id"]),
+    )
+
+    op.create_table(
+        "order_items",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("order_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("product_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("width", sa.Integer(), nullable=False),
+        sa.Column("height", sa.Integer(), nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("unit_price", sa.Numeric(10, 2), nullable=False),
+        sa.Column("total_price", sa.Numeric(10, 2), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"]),
+    )
+
+    op.create_table(
+        "production_stations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("code", sa.String(length=50), nullable=False),
+        sa.Column("order_index", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("code", name="uq_production_stations_code"),
+    )
+
+    op.create_table(
+        "production_jobs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("order_item_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("quantity_required", sa.Integer(), nullable=False),
+        sa.Column("quantity_produced", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["order_item_id"], ["order_items.id"]),
+    )
+
+    op.create_table(
+        "production_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("job_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("station_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["job_id"], ["production_jobs.id"]),
+        sa.ForeignKeyConstraint(["station_id"], ["production_stations.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+    )
+
+    op.create_table(
+        "purchase_orders",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("partner_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("grand_total", sa.Numeric(10, 2), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["partner_id"], ["partners.id"]),
+    )
+
+    op.create_table(
+        "purchase_order_items",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("purchase_order_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("material_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("unit_price", sa.Numeric(10, 2), nullable=False),
+        sa.Column("total_price", sa.Numeric(10, 2), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["purchase_order_id"], ["purchase_orders.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["material_id"], ["materials.id"]),
+    )
+
+    op.create_table(
+        "accounts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("current_balance", sa.Numeric(10, 2), server_default="0", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "financial_transactions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("account_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("partner_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("order_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("purchase_order_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("direction", sa.String(length=10), nullable=False),
+        sa.Column("amount", sa.Numeric(10, 2), nullable=False),
+        sa.Column("transaction_date", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=sa.func.now()),
+        sa.CheckConstraint(
+            "direction IN ('IN','OUT')",
+            name="ck_financial_transactions_direction",
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["account_id"], ["accounts.id"]),
+        sa.ForeignKeyConstraint(["partner_id"], ["partners.id"]),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"]),
+        sa.ForeignKeyConstraint(["purchase_order_id"], ["purchase_orders.id"]),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("financial_transactions")
+    op.drop_table("accounts")
+    op.drop_table("purchase_order_items")
+    op.drop_table("purchase_orders")
+    op.drop_table("production_logs")
+    op.drop_table("production_jobs")
+    op.drop_table("production_stations")
+    op.drop_table("order_items")
+    op.drop_table("orders")
+    op.drop_table("products")
+    op.drop_table("materials")
+    op.drop_table("partners")
+    op.drop_table("users")
+    op.drop_table("roles")
+    op.drop_table("organizations")
+

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -1,3 +1,28 @@
+"""Base class for SQLAlchemy models and model imports for Alembic."""
+
 from sqlalchemy.orm import declarative_base
 
+
 Base = declarative_base()
+
+
+# Import all model classes so that Alembic can detect them via Base.metadata
+# noqa: F401
+from app.models import (  # type: ignore  # pylint: disable=unused-import
+    Account,
+    FinancialTransaction,
+    Material,
+    Order,
+    OrderItem,
+    Organization,
+    Partner,
+    Product,
+    ProductionJob,
+    ProductionLog,
+    ProductionStation,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    Role,
+    User,
+)
+

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,23 @@
+# Import all models here for easy access
+from .organization import Organization
+from .user import User
+from .role import Role
+from .partner import Partner
+from .order import Order
+from .order_item import OrderItem
+from .production_station import ProductionStation
+from .production_job import ProductionJob
+from .production_log import ProductionLog
+from .material import Material
+from .product import Product
+from .purchase_order import PurchaseOrder
+from .purchase_order_item import PurchaseOrderItem
+from .account import Account
+from .financial_transaction import FinancialTransaction
+
+__all__ = [
+    'Organization', 'User', 'Role', 'Partner', 'Order', 'OrderItem',
+    'ProductionStation', 'ProductionJob', 'ProductionLog', 'Material',
+    'Product', 'PurchaseOrder', 'PurchaseOrderItem', 'Account',
+    'FinancialTransaction'
+]

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -1,0 +1,22 @@
+"""Account model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Numeric, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Account(Base):
+    __tablename__ = "accounts"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    name = Column(String(255), nullable=False)
+    current_balance = Column(Numeric(10, 2), nullable=False, server_default="0")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/models/financial_transaction.py
+++ b/backend/app/models/financial_transaction.py
@@ -1,0 +1,40 @@
+"""Financial transaction model."""
+
+import uuid
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class FinancialTransaction(Base):
+    __tablename__ = "financial_transactions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    account_id = Column(UUID(as_uuid=True), ForeignKey("accounts.id"), nullable=False)
+    partner_id = Column(UUID(as_uuid=True), ForeignKey("partners.id"))
+    order_id = Column(UUID(as_uuid=True), ForeignKey("orders.id"))
+    purchase_order_id = Column(UUID(as_uuid=True), ForeignKey("purchase_orders.id"))
+    direction = Column(String(10), nullable=False)
+    amount = Column(Numeric(10, 2), nullable=False)
+    transaction_date = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    description = Column(String(255))
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    __table_args__ = (
+        CheckConstraint("direction IN ('IN','OUT')", name="ck_financial_transactions_direction"),
+    )
+

--- a/backend/app/models/material.py
+++ b/backend/app/models/material.py
@@ -1,0 +1,22 @@
+"""Material model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Numeric, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Material(Base):
+    __tablename__ = "materials"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    name = Column(String(255), nullable=False)
+    stock_quantity = Column(Numeric(10, 2), nullable=False, server_default="0")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,0 +1,29 @@
+"""Order model."""
+
+import uuid
+
+from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, Numeric, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Order(Base):
+    __tablename__ = "orders"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    partner_id = Column(UUID(as_uuid=True), ForeignKey("partners.id"), nullable=False)
+    status = Column(String(50), nullable=False)
+    total_amount = Column(Numeric(10, 2), nullable=False, server_default="0")
+    tax_amount = Column(Numeric(10, 2), nullable=False, server_default="0")
+    grand_total = Column(Numeric(10, 2), nullable=False, server_default="0")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    __table_args__ = (
+        CheckConstraint("status IN ('TEKLIF','SIPARIS','URETIMDE')", name="ck_orders_status"),
+    )
+

--- a/backend/app/models/order_item.py
+++ b/backend/app/models/order_item.py
@@ -1,0 +1,27 @@
+"""Order item model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class OrderItem(Base):
+    __tablename__ = "order_items"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    order_id = Column(UUID(as_uuid=True), ForeignKey("orders.id", ondelete="CASCADE"), nullable=False)
+    product_id = Column(UUID(as_uuid=True), ForeignKey("products.id"), nullable=False)
+    width = Column(Integer, nullable=False)
+    height = Column(Integer, nullable=False)
+    quantity = Column(Integer, nullable=False)
+    unit_price = Column(Numeric(10, 2), nullable=False)
+    total_price = Column(Numeric(10, 2), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -1,0 +1,20 @@
+"""Organization model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Organization(Base):
+    """Represents a tenant organization."""
+
+    __tablename__ = "organizations"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String(255), nullable=False)
+    slug = Column(String(50), unique=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+

--- a/backend/app/models/partner.py
+++ b/backend/app/models/partner.py
@@ -1,0 +1,27 @@
+"""Partner model for customers and suppliers."""
+
+import uuid
+
+from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Partner(Base):
+    __tablename__ = "partners"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    type = Column(String(50), nullable=False)
+    name = Column(String(255), nullable=False)
+    email = Column(String(255), unique=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    __table_args__ = (
+        CheckConstraint("type IN ('CUSTOMER','SUPPLIER','BOTH')", name="ck_partners_type"),
+    )
+

--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -1,0 +1,22 @@
+"""Product model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Numeric, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    name = Column(String(255), nullable=False)
+    base_price_sqm = Column(Numeric(10, 2), nullable=False, server_default="0")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/models/production_job.py
+++ b/backend/app/models/production_job.py
@@ -1,0 +1,23 @@
+"""Production job model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class ProductionJob(Base):
+    __tablename__ = "production_jobs"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    order_item_id = Column(UUID(as_uuid=True), ForeignKey("order_items.id"), nullable=False)
+    quantity_required = Column(Integer, nullable=False)
+    quantity_produced = Column(Integer, nullable=False, server_default="0")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/models/production_log.py
+++ b/backend/app/models/production_log.py
@@ -1,0 +1,21 @@
+"""Production log model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class ProductionLog(Base):
+    __tablename__ = "production_logs"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    job_id = Column(UUID(as_uuid=True), ForeignKey("production_jobs.id"), nullable=False)
+    station_id = Column(UUID(as_uuid=True), ForeignKey("production_stations.id"), nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    completed_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    quantity = Column(Integer, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+

--- a/backend/app/models/production_station.py
+++ b/backend/app/models/production_station.py
@@ -1,0 +1,23 @@
+"""Production station model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class ProductionStation(Base):
+    __tablename__ = "production_stations"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    name = Column(String(255), nullable=False)
+    code = Column(String(50), unique=True, nullable=False)
+    order_index = Column(Integer, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/models/purchase_order.py
+++ b/backend/app/models/purchase_order.py
@@ -1,0 +1,22 @@
+"""Purchase order model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Numeric, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class PurchaseOrder(Base):
+    __tablename__ = "purchase_orders"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    partner_id = Column(UUID(as_uuid=True), ForeignKey("partners.id"), nullable=False)
+    grand_total = Column(Numeric(10, 2), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/models/purchase_order_item.py
+++ b/backend/app/models/purchase_order_item.py
@@ -1,0 +1,24 @@
+"""Purchase order item model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class PurchaseOrderItem(Base):
+    __tablename__ = "purchase_order_items"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    purchase_order_id = Column(
+        UUID(as_uuid=True), ForeignKey("purchase_orders.id", ondelete="CASCADE"), nullable=False
+    )
+    material_id = Column(UUID(as_uuid=True), ForeignKey("materials.id"))
+    quantity = Column(Integer, nullable=False)
+    unit_price = Column(Numeric(10, 2), nullable=False)
+    total_price = Column(Numeric(10, 2), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/models/role.py
+++ b/backend/app/models/role.py
@@ -1,0 +1,22 @@
+"""Role model."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from app.db.base import Base
+
+
+class Role(Base):
+    __tablename__ = "roles"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    name = Column(String(50), nullable=False)
+    permissions = Column(JSONB, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,26 @@
+"""User model."""
+
+import uuid
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    email = Column(String(255), unique=True, nullable=False)
+    hashed_password = Column(String(255), nullable=False)
+    first_name = Column(String(100))
+    last_name = Column(String(100))
+    role_id = Column(UUID(as_uuid=True), ForeignKey("roles.id"), nullable=False)
+    is_active = Column(Boolean, nullable=False, server_default="true")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for core ERP entities
- provide Alembic environment and initial migration creating all tables

## Testing
- `alembic upgrade head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad88eaf224832d9a88d6e6af96528a