### PR TITLE
Add partner and product CRUD APIs

### DIFF
--- a/backend/app/api/partners.py
+++ b/backend/app/api/partners.py
@@ -1,0 +1,70 @@
+"""Partner CRUD endpoints."""
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+from app.schemas.partner import PartnerCreate, PartnerUpdate, PartnerPublic
+from app.services.partner_service import (
+    create_partner,
+    get_partner,
+    get_partners,
+    update_partner,
+    delete_partner,
+)
+
+router = APIRouter(prefix="/api/partners", tags=["partners"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=PartnerPublic)
+def create_partner_endpoint(
+    partner_in: PartnerCreate, db: Session = Depends(get_db)
+) -> PartnerPublic:
+    return create_partner(db, partner_in)
+
+
+@router.get("/{partner_id}", response_model=PartnerPublic)
+def read_partner(partner_id: UUID, db: Session = Depends(get_db)) -> PartnerPublic:
+    partner = get_partner(db, partner_id)
+    if not partner:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner not found")
+    return partner
+
+
+@router.get("/", response_model=List[PartnerPublic])
+def list_partners(
+    page: int = 1,
+    page_size: int = 10,
+    search_query: str | None = None,
+    db: Session = Depends(get_db),
+) -> List[PartnerPublic]:
+    return get_partners(db, page, page_size, search_query)
+
+
+@router.put("/{partner_id}", response_model=PartnerPublic)
+def update_partner_endpoint(
+    partner_id: UUID, partner_in: PartnerUpdate, db: Session = Depends(get_db)
+) -> PartnerPublic:
+    partner = update_partner(db, partner_id, partner_in)
+    if not partner:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner not found")
+    return partner
+
+
+@router.delete("/{partner_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_partner_endpoint(partner_id: UUID, db: Session = Depends(get_db)) -> None:
+    success = delete_partner(db, partner_id)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner not found")
+    return None

--- a/backend/app/api/products.py
+++ b/backend/app/api/products.py
@@ -1,0 +1,70 @@
+"""Product CRUD endpoints."""
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+from app.schemas.product import ProductCreate, ProductUpdate, ProductPublic
+from app.services.product_service import (
+    create_product,
+    get_product,
+    get_products,
+    update_product,
+    delete_product,
+)
+
+router = APIRouter(prefix="/api/products", tags=["products"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=ProductPublic)
+def create_product_endpoint(
+    product_in: ProductCreate, db: Session = Depends(get_db)
+) -> ProductPublic:
+    return create_product(db, product_in)
+
+
+@router.get("/{product_id}", response_model=ProductPublic)
+def read_product(product_id: UUID, db: Session = Depends(get_db)) -> ProductPublic:
+    product = get_product(db, product_id)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return product
+
+
+@router.get("/", response_model=List[ProductPublic])
+def list_products(
+    page: int = 1,
+    page_size: int = 10,
+    search_query: str | None = None,
+    db: Session = Depends(get_db),
+) -> List[ProductPublic]:
+    return get_products(db, page, page_size, search_query)
+
+
+@router.put("/{product_id}", response_model=ProductPublic)
+def update_product_endpoint(
+    product_id: UUID, product_in: ProductUpdate, db: Session = Depends(get_db)
+) -> ProductPublic:
+    product = update_product(db, product_id, product_in)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return product
+
+
+@router.delete("/{product_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_product_endpoint(product_id: UUID, db: Session = Depends(get_db)) -> None:
+    success = delete_product(db, product_id)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,10 @@
 from fastapi import FastAPI
 
 from app.api.auth import router as auth_router
+from app.api.partners import router as partners_router
+from app.api.products import router as products_router
 
 app = FastAPI()
 app.include_router(auth_router)
+app.include_router(partners_router)
+app.include_router(products_router)

--- a/backend/app/schemas/partner.py
+++ b/backend/app/schemas/partner.py
@@ -1,0 +1,29 @@
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+PartnerType = Literal["CUSTOMER", "SUPPLIER", "BOTH"]
+
+
+class PartnerCreate(BaseModel):
+    type: PartnerType
+    name: str
+    email: EmailStr | None = None
+
+
+class PartnerUpdate(BaseModel):
+    type: PartnerType | None = None
+    name: str | None = None
+    email: EmailStr | None = None
+
+
+class PartnerPublic(BaseModel):
+    id: UUID
+    organization_id: UUID
+    type: PartnerType
+    name: str
+    email: EmailStr | None = None
+
+    class Config:
+        orm_mode = True

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class ProductCreate(BaseModel):
+    name: str
+    base_price_sqm: Decimal
+
+
+class ProductUpdate(BaseModel):
+    name: str | None = None
+    base_price_sqm: Decimal | None = None
+
+
+class ProductPublic(BaseModel):
+    id: UUID
+    organization_id: UUID
+    name: str
+    base_price_sqm: Decimal
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/partner_service.py
+++ b/backend/app/services/partner_service.py
@@ -1,0 +1,63 @@
+"""Service layer for partner operations."""
+
+import uuid
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models.partner import Partner
+from app.schemas.partner import PartnerCreate, PartnerUpdate
+
+DEFAULT_ORGANIZATION_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+def create_partner(db: Session, partner_in: PartnerCreate) -> Partner:
+    partner = Partner(
+        organization_id=DEFAULT_ORGANIZATION_ID,
+        type=partner_in.type,
+        name=partner_in.name,
+        email=partner_in.email,
+    )
+    db.add(partner)
+    db.commit()
+    db.refresh(partner)
+    return partner
+
+
+def get_partner(db: Session, partner_id: UUID) -> Optional[Partner]:
+    return db.query(Partner).filter(Partner.id == partner_id).first()
+
+
+def get_partners(
+    db: Session,
+    page: int = 1,
+    page_size: int = 10,
+    search_query: str | None = None,
+) -> List[Partner]:
+    query = db.query(Partner)
+    if search_query:
+        query = query.filter(Partner.name.ilike(f"%{search_query}%"))
+    return query.offset((page - 1) * page_size).limit(page_size).all()
+
+
+def update_partner(
+    db: Session, partner_id: UUID, partner_in: PartnerUpdate
+) -> Optional[Partner]:
+    partner = get_partner(db, partner_id)
+    if not partner:
+        return None
+    for field, value in partner_in.dict(exclude_unset=True).items():
+        setattr(partner, field, value)
+    db.commit()
+    db.refresh(partner)
+    return partner
+
+
+def delete_partner(db: Session, partner_id: UUID) -> bool:
+    partner = get_partner(db, partner_id)
+    if not partner:
+        return False
+    db.delete(partner)
+    db.commit()
+    return True

--- a/backend/app/services/product_service.py
+++ b/backend/app/services/product_service.py
@@ -1,0 +1,62 @@
+"""Service layer for product operations."""
+
+import uuid
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models.product import Product
+from app.schemas.product import ProductCreate, ProductUpdate
+
+DEFAULT_ORGANIZATION_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+def create_product(db: Session, product_in: ProductCreate) -> Product:
+    product = Product(
+        organization_id=DEFAULT_ORGANIZATION_ID,
+        name=product_in.name,
+        base_price_sqm=product_in.base_price_sqm,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def get_product(db: Session, product_id: UUID) -> Optional[Product]:
+    return db.query(Product).filter(Product.id == product_id).first()
+
+
+def get_products(
+    db: Session,
+    page: int = 1,
+    page_size: int = 10,
+    search_query: str | None = None,
+) -> List[Product]:
+    query = db.query(Product)
+    if search_query:
+        query = query.filter(Product.name.ilike(f"%{search_query}%"))
+    return query.offset((page - 1) * page_size).limit(page_size).all()
+
+
+def update_product(
+    db: Session, product_id: UUID, product_in: ProductUpdate
+) -> Optional[Product]:
+    product = get_product(db, product_id)
+    if not product:
+        return None
+    for field, value in product_in.dict(exclude_unset=True).items():
+        setattr(product, field, value)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def delete_product(db: Session, product_id: UUID) -> bool:
+    product = get_product(db, product_id)
+    if not product:
+        return False
+    db.delete(product)
+    db.commit()
+    return True


### PR DESCRIPTION
## Summary
- add partner and product schemas
- implement partner/product service layers
- expose CRUD routers with pagination and search
- wire routers into FastAPI app

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad8c666648832dbf870d4942361a52