### PR TITLE
Add order and order item CRUD APIs

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -1,0 +1,75 @@
+"""Order CRUD endpoints."""
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+from app.schemas.order import OrderCreate, OrderUpdate, OrderPublic, OrderStatus
+from app.services.order_service import (
+    create_order,
+    get_order,
+    get_orders,
+    update_order,
+    delete_order,
+)
+
+router = APIRouter(prefix="/api/orders", tags=["orders"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=OrderPublic)
+def create_order_endpoint(order_in: OrderCreate, db: Session = Depends(get_db)) -> OrderPublic:
+    try:
+        return create_order(db, order_in)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@router.get("/", response_model=List[OrderPublic])
+def list_orders(
+    page: int = 1,
+    page_size: int = 10,
+    partner_id: UUID | None = None,
+    status: OrderStatus | None = None,
+    db: Session = Depends(get_db),
+) -> List[OrderPublic]:
+    return get_orders(db, page, page_size, partner_id, status)
+
+
+@router.get("/{order_id}", response_model=OrderPublic)
+def read_order(order_id: UUID, db: Session = Depends(get_db)) -> OrderPublic:
+    order = get_order(db, order_id)
+    if not order:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Order not found")
+    return order
+
+
+@router.put("/{order_id}", response_model=OrderPublic)
+def update_order_endpoint(
+    order_id: UUID, order_in: OrderUpdate, db: Session = Depends(get_db)
+) -> OrderPublic:
+    try:
+        order = update_order(db, order_id, order_in)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    if not order:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Order not found")
+    return order
+
+
+@router.delete("/{order_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_order_endpoint(order_id: UUID, db: Session = Depends(get_db)) -> None:
+    success = delete_order(db, order_id)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Order not found")
+    return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,8 +5,10 @@ from fastapi import FastAPI
 from app.api.auth import router as auth_router
 from app.api.partners import router as partners_router
 from app.api.products import router as products_router
+from app.api.orders import router as orders_router
 
 app = FastAPI()
 app.include_router(auth_router)
 app.include_router(partners_router)
 app.include_router(products_router)
+app.include_router(orders_router)

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -1,0 +1,35 @@
+from decimal import Decimal
+from typing import List, Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from .order_item import OrderItemCreate, OrderItemUpdate, OrderItemPublic
+
+OrderStatus = Literal["TEKLIF", "SIPARIS", "URETIMDE"]
+
+
+class OrderCreate(BaseModel):
+    partner_id: UUID
+    status: OrderStatus
+    order_items: List[OrderItemCreate]
+
+
+class OrderUpdate(BaseModel):
+    partner_id: UUID | None = None
+    status: OrderStatus | None = None
+    order_items: List[OrderItemUpdate] | None = None
+
+
+class OrderPublic(BaseModel):
+    id: UUID
+    organization_id: UUID
+    partner_id: UUID
+    status: OrderStatus
+    total_amount: Decimal
+    tax_amount: Decimal
+    grand_total: Decimal
+    order_items: List[OrderItemPublic]
+
+    class Config:
+        orm_mode = True

--- a/backend/app/schemas/order_item.py
+++ b/backend/app/schemas/order_item.py
@@ -1,0 +1,31 @@
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class OrderItemCreate(BaseModel):
+    product_id: UUID
+    width: int
+    height: int
+    quantity: int
+
+
+class OrderItemUpdate(BaseModel):
+    product_id: UUID
+    width: int
+    height: int
+    quantity: int
+
+
+class OrderItemPublic(BaseModel):
+    id: UUID
+    product_id: UUID
+    width: int
+    height: int
+    quantity: int
+    unit_price: Decimal
+    total_price: Decimal
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -1,0 +1,118 @@
+"""Service layer for order operations."""
+
+import uuid
+from decimal import Decimal
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models.order import Order
+from app.models.order_item import OrderItem
+from app.models.product import Product
+from app.schemas.order import OrderCreate, OrderUpdate
+
+DEFAULT_ORGANIZATION_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+TAX_RATE = Decimal("0.18")
+
+
+def _create_order_item(db: Session, order_id: UUID, item_in) -> Decimal:
+    """Helper to create an order item and return its total price."""
+    product = db.query(Product).filter(Product.id == item_in.product_id).first()
+    if not product:
+        raise ValueError("Product not found")
+    unit_price = product.base_price_sqm
+    area_sqm = (Decimal(item_in.width) * Decimal(item_in.height)) / Decimal(1_000_000)
+    total_price = unit_price * area_sqm * item_in.quantity
+    order_item = OrderItem(
+        organization_id=DEFAULT_ORGANIZATION_ID,
+        order_id=order_id,
+        product_id=item_in.product_id,
+        width=item_in.width,
+        height=item_in.height,
+        quantity=item_in.quantity,
+        unit_price=unit_price,
+        total_price=total_price,
+    )
+    db.add(order_item)
+    return total_price
+
+
+def create_order(db: Session, order_in: OrderCreate) -> Order:
+    order = Order(
+        organization_id=DEFAULT_ORGANIZATION_ID,
+        partner_id=order_in.partner_id,
+        status=order_in.status,
+    )
+    db.add(order)
+    db.flush()
+    total_amount = Decimal("0")
+    for item in order_in.order_items:
+        total_amount += _create_order_item(db, order.id, item)
+    order.total_amount = total_amount
+    order.tax_amount = total_amount * TAX_RATE
+    order.grand_total = order.total_amount + order.tax_amount
+    db.commit()
+    db.refresh(order)
+    order.order_items = (
+        db.query(OrderItem).filter(OrderItem.order_id == order.id).all()
+    )
+    return order
+
+
+def get_order(db: Session, order_id: UUID) -> Optional[Order]:
+    order = db.query(Order).filter(Order.id == order_id).first()
+    if not order:
+        return None
+    order.order_items = db.query(OrderItem).filter(OrderItem.order_id == order_id).all()
+    return order
+
+
+def get_orders(
+    db: Session,
+    page: int = 1,
+    page_size: int = 10,
+    partner_id: UUID | None = None,
+    status: str | None = None,
+) -> List[Order]:
+    query = db.query(Order)
+    if partner_id:
+        query = query.filter(Order.partner_id == partner_id)
+    if status:
+        query = query.filter(Order.status == status)
+    orders = query.offset((page - 1) * page_size).limit(page_size).all()
+    for order in orders:
+        order.order_items = db.query(OrderItem).filter(OrderItem.order_id == order.id).all()
+    return orders
+
+
+def update_order(db: Session, order_id: UUID, order_in: OrderUpdate) -> Optional[Order]:
+    order = db.query(Order).filter(Order.id == order_id).first()
+    if not order:
+        return None
+    for field in ["partner_id", "status"]:
+        value = getattr(order_in, field)
+        if value is not None:
+            setattr(order, field, value)
+    if order_in.order_items is not None:
+        db.query(OrderItem).filter(OrderItem.order_id == order.id).delete()
+        db.flush()
+        total_amount = Decimal("0")
+        for item in order_in.order_items:
+            total_amount += _create_order_item(db, order.id, item)
+        order.total_amount = total_amount
+        order.tax_amount = total_amount * TAX_RATE
+        order.grand_total = order.total_amount + order.tax_amount
+    db.commit()
+    db.refresh(order)
+    order.order_items = db.query(OrderItem).filter(OrderItem.order_id == order.id).all()
+    return order
+
+
+def delete_order(db: Session, order_id: UUID) -> bool:
+    order = db.query(Order).filter(Order.id == order_id).first()
+    if not order:
+        return False
+    db.delete(order)
+    db.commit()
+    return True


### PR DESCRIPTION
## Summary
- add Pydantic schemas for orders and order items
- implement service layer for creating, reading, updating and deleting orders with items
- expose new `/api/orders` CRUD endpoints and wire them into the app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad92d12e2c832d9d8c74c103e80d96