### PR TITLE
feat: add production job tracking

### DIFF
--- a/alembic/versions/0002_add_status_to_production_jobs_and_seed_stations.py
+++ b/alembic/versions/0002_add_status_to_production_jobs_and_seed_stations.py
@@ -1,0 +1,44 @@
+"""add status to production jobs and seed stations"""
+
+from alembic import op
+import sqlalchemy as sa
+import uuid
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+DEFAULT_ORGANIZATION_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+STATIONS = [
+    ("Cam Kesim", "CAM_KESIM", 1),
+    ("Pres", "PRES", 2),
+]
+
+
+def upgrade() -> None:
+    op.add_column(
+        "production_jobs",
+        sa.Column("status", sa.String(length=50), server_default="PENDING", nullable=False),
+    )
+    for name, code, order_index in STATIONS:
+        op.execute(
+            sa.text(
+                "INSERT INTO production_stations (id, organization_id, name, code, order_index) "
+                "SELECT :id, :org, :name, :code, :order_index "
+                "WHERE NOT EXISTS (SELECT 1 FROM production_stations WHERE code=:code)"
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "org": str(DEFAULT_ORGANIZATION_ID),
+                "name": name,
+                "code": code,
+                "order_index": order_index,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("production_jobs", "status")
+    for _, code, _ in STATIONS:
+        op.execute(sa.text("DELETE FROM production_stations WHERE code=:code"), {"code": code})

--- a/backend/app/api/production.py
+++ b/backend/app/api/production.py
@@ -1,0 +1,57 @@
+"""Production job and log endpoints."""
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+from app.schemas.production import (
+    ProductionJobPublic,
+    ProductionLogCreate,
+    ProductionLogPublic,
+)
+from app.services.production_service import (
+    get_jobs,
+    get_job_detail,
+    log_production_step,
+)
+
+router = APIRouter(prefix="/api/production", tags=["production"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/jobs", response_model=List[ProductionJobPublic])
+def list_jobs(
+    page: int = 1,
+    page_size: int = 10,
+    status: str | None = None,
+    db: Session = Depends(get_db),
+) -> List[ProductionJobPublic]:
+    return get_jobs(db, page, page_size, status)
+
+
+@router.get("/jobs/{job_id}", response_model=ProductionJobPublic)
+def read_job(job_id: UUID, db: Session = Depends(get_db)) -> ProductionJobPublic:
+    job = get_job_detail(db, job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job
+
+
+@router.post("/jobs/{job_id}/logs", response_model=ProductionLogPublic)
+def create_log(
+    job_id: UUID, log_in: ProductionLogCreate, db: Session = Depends(get_db)
+) -> ProductionLogPublic:
+    try:
+        return log_production_step(db, job_id, log_in)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,9 +6,11 @@ from app.api.auth import router as auth_router
 from app.api.partners import router as partners_router
 from app.api.products import router as products_router
 from app.api.orders import router as orders_router
+from app.api.production import router as production_router
 
 app = FastAPI()
 app.include_router(auth_router)
 app.include_router(partners_router)
 app.include_router(products_router)
 app.include_router(orders_router)
+app.include_router(production_router)

--- a/backend/app/models/production_job.py
+++ b/backend/app/models/production_job.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, func
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.db.base import Base
@@ -18,6 +18,7 @@ class ProductionJob(Base):
     order_item_id = Column(UUID(as_uuid=True), ForeignKey("order_items.id"), nullable=False)
     quantity_required = Column(Integer, nullable=False)
     quantity_produced = Column(Integer, nullable=False, server_default="0")
+    status = Column(String(50), nullable=False, server_default="PENDING")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/schemas/production.py
+++ b/backend/app/schemas/production.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from typing import List, Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+JobStatus = Literal["PENDING", "IN_PROGRESS", "COMPLETED"]
+
+
+class ProductionLogCreate(BaseModel):
+    station_id: UUID
+    user_id: UUID
+    quantity: int
+
+
+class ProductionLogPublic(BaseModel):
+    id: UUID
+    job_id: UUID
+    station_id: UUID
+    user_id: UUID
+    completed_at: datetime
+    quantity: int
+
+    class Config:
+        orm_mode = True
+
+
+class ProductionJobCreate(BaseModel):
+    order_item_id: UUID
+    quantity_required: int
+
+
+class ProductionJobUpdate(BaseModel):
+    status: JobStatus | None = None
+    quantity_produced: int | None = None
+
+
+class ProductionJobPublic(BaseModel):
+    id: UUID
+    organization_id: UUID
+    order_item_id: UUID
+    quantity_required: int
+    quantity_produced: int
+    status: JobStatus
+    logs: List[ProductionLogPublic]
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -11,6 +11,7 @@ from app.models.order import Order
 from app.models.order_item import OrderItem
 from app.models.product import Product
 from app.schemas.order import OrderCreate, OrderUpdate
+from app.services.production_service import create_job_from_order_item
 
 DEFAULT_ORGANIZATION_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 TAX_RATE = Decimal("0.18")
@@ -35,6 +36,8 @@ def _create_order_item(db: Session, order_id: UUID, item_in) -> Decimal:
         total_price=total_price,
     )
     db.add(order_item)
+    db.flush()
+    create_job_from_order_item(db, order_item.id)
     return total_price
 
 

--- a/backend/app/services/production_service.py
+++ b/backend/app/services/production_service.py
@@ -1,0 +1,92 @@
+"""Service layer for production operations."""
+
+import uuid
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models.order_item import OrderItem
+from app.models.production_job import ProductionJob
+from app.models.production_log import ProductionLog
+from app.models.production_station import ProductionStation
+from app.schemas.production import ProductionLogCreate
+
+DEFAULT_ORGANIZATION_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+DEFAULT_STATIONS = [
+    ("Cam Kesim", "CAM_KESIM", 1),
+    ("Pres", "PRES", 2),
+]
+
+
+def _ensure_default_stations(db: Session) -> None:
+    for name, code, order_index in DEFAULT_STATIONS:
+        exists = db.query(ProductionStation).filter(ProductionStation.code == code).first()
+        if not exists:
+            station = ProductionStation(
+                organization_id=DEFAULT_ORGANIZATION_ID,
+                name=name,
+                code=code,
+                order_index=order_index,
+            )
+            db.add(station)
+    db.flush()
+
+
+def create_job_from_order_item(db: Session, order_item_id: UUID) -> ProductionJob:
+    order_item = db.query(OrderItem).filter(OrderItem.id == order_item_id).first()
+    if not order_item:
+        raise ValueError("Order item not found")
+    _ensure_default_stations(db)
+    job = ProductionJob(
+        organization_id=DEFAULT_ORGANIZATION_ID,
+        order_item_id=order_item_id,
+        quantity_required=order_item.quantity,
+    )
+    db.add(job)
+    db.flush()
+    return job
+
+
+def get_jobs(
+    db: Session,
+    page: int = 1,
+    page_size: int = 10,
+    status: str | None = None,
+) -> List[ProductionJob]:
+    query = db.query(ProductionJob)
+    if status:
+        query = query.filter(ProductionJob.status == status)
+    jobs = query.offset((page - 1) * page_size).limit(page_size).all()
+    for job in jobs:
+        job.logs = []
+    return jobs
+
+
+def get_job_detail(db: Session, job_id: UUID) -> Optional[ProductionJob]:
+    job = db.query(ProductionJob).filter(ProductionJob.id == job_id).first()
+    if not job:
+        return None
+    job.logs = db.query(ProductionLog).filter(ProductionLog.job_id == job_id).all()
+    return job
+
+
+def log_production_step(db: Session, job_id: UUID, log_in: ProductionLogCreate) -> ProductionLog:
+    job = db.query(ProductionJob).filter(ProductionJob.id == job_id).first()
+    if not job:
+        raise ValueError("Job not found")
+    log = ProductionLog(
+        job_id=job_id,
+        station_id=log_in.station_id,
+        user_id=log_in.user_id,
+        quantity=log_in.quantity,
+    )
+    db.add(log)
+    job.quantity_produced += log_in.quantity
+    if job.quantity_produced >= job.quantity_required:
+        job.status = "COMPLETED"
+    elif job.quantity_produced > 0:
+        job.status = "IN_PROGRESS"
+    db.commit()
+    db.refresh(log)
+    return log


### PR DESCRIPTION
## Summary
- add production job and log schemas and services
- create production API for jobs and logs
- generate jobs from order items and track status updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad948e7060832db0ee96a6f485c640