### PR TITLE
Add financial accounts and transactions API

### DIFF
--- a/backend/app/api/financial.py
+++ b/backend/app/api/financial.py
@@ -1,0 +1,178 @@
+"""Financial accounts and transactions endpoints."""
+
+from decimal import Decimal
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+from app.schemas.financial import (
+    AccountCreate,
+    AccountUpdate,
+    AccountPublic,
+    FinancialTransactionCreate,
+    FinancialTransactionUpdate,
+    FinancialTransactionPublic,
+)
+from app.services.financial_service import (
+    create_account,
+    get_account,
+    get_accounts,
+    update_account,
+    delete_account,
+    get_account_balance,
+    create_transaction,
+    get_transaction,
+    list_transactions,
+    update_transaction,
+    delete_transaction,
+    create_payment_for_order,
+)
+
+router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Account endpoints
+# ---------------------------------------------------------------------------
+accounts_router = APIRouter(prefix="/api/accounts", tags=["accounts"])
+
+
+@accounts_router.post("/", response_model=AccountPublic)
+def create_account_endpoint(account_in: AccountCreate, db: Session = Depends(get_db)) -> AccountPublic:
+    return create_account(db, account_in)
+
+
+@accounts_router.get("/{account_id}", response_model=AccountPublic)
+def read_account(account_id: UUID, db: Session = Depends(get_db)) -> AccountPublic:
+    account = get_account(db, account_id)
+    if not account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return account
+
+
+@accounts_router.get("/", response_model=List[AccountPublic])
+def list_accounts(page: int = 1, page_size: int = 10, db: Session = Depends(get_db)) -> List[AccountPublic]:
+    return get_accounts(db, page, page_size)
+
+
+@accounts_router.put("/{account_id}", response_model=AccountPublic)
+def update_account_endpoint(account_id: UUID, account_in: AccountUpdate, db: Session = Depends(get_db)) -> AccountPublic:
+    account = update_account(db, account_id, account_in)
+    if not account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return account
+
+
+@accounts_router.delete("/{account_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_account_endpoint(account_id: UUID, db: Session = Depends(get_db)) -> None:
+    success = delete_account(db, account_id)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return None
+
+
+class BalanceResponse(BaseModel):
+    balance: Decimal
+
+
+@accounts_router.get("/{account_id}/balance", response_model=BalanceResponse)
+def account_balance(account_id: UUID, db: Session = Depends(get_db)) -> BalanceResponse:
+    balance = get_account_balance(db, account_id)
+    if balance is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return BalanceResponse(balance=balance)
+
+
+# ---------------------------------------------------------------------------
+# Financial transaction endpoints
+# ---------------------------------------------------------------------------
+transactions_router = APIRouter(prefix="/api/transactions", tags=["transactions"])
+
+
+@transactions_router.post("/", response_model=FinancialTransactionPublic)
+def create_transaction_endpoint(transaction_in: FinancialTransactionCreate, db: Session = Depends(get_db)) -> FinancialTransactionPublic:
+    try:
+        return create_transaction(db, transaction_in)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@transactions_router.get("/{transaction_id}", response_model=FinancialTransactionPublic)
+def read_transaction(transaction_id: UUID, db: Session = Depends(get_db)) -> FinancialTransactionPublic:
+    transaction = get_transaction(db, transaction_id)
+    if not transaction:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    return transaction
+
+
+@transactions_router.get("/", response_model=List[FinancialTransactionPublic])
+def list_transactions_endpoint(
+    page: int = 1,
+    page_size: int = 10,
+    account_id: UUID | None = None,
+    direction: str | None = None,
+    db: Session = Depends(get_db),
+) -> List[FinancialTransactionPublic]:
+    return list_transactions(db, page, page_size, account_id, direction)
+
+
+@transactions_router.put("/{transaction_id}", response_model=FinancialTransactionPublic)
+def update_transaction_endpoint(
+    transaction_id: UUID, transaction_in: FinancialTransactionUpdate, db: Session = Depends(get_db)
+) -> FinancialTransactionPublic:
+    transaction = update_transaction(db, transaction_id, transaction_in)
+    if not transaction:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    return transaction
+
+
+@transactions_router.delete("/{transaction_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_transaction_endpoint(transaction_id: UUID, db: Session = Depends(get_db)) -> None:
+    success = delete_transaction(db, transaction_id)
+    if not success:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Order payment endpoint
+# ---------------------------------------------------------------------------
+
+
+class OrderPaymentCreate(BaseModel):
+    account_id: UUID
+    amount: Decimal
+    description: str | None = None
+
+
+@router.post("/api/orders/{order_id}/payments", response_model=FinancialTransactionPublic, tags=["orders"])
+def create_payment_for_order_endpoint(
+    order_id: UUID, payment_in: OrderPaymentCreate, db: Session = Depends(get_db)
+) -> FinancialTransactionPublic:
+    try:
+        return create_payment_for_order(
+            db,
+            order_id=order_id,
+            account_id=payment_in.account_id,
+            amount=payment_in.amount,
+            description=payment_in.description,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+
+# Include sub-routers
+router.include_router(accounts_router)
+router.include_router(transactions_router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from app.api.partners import router as partners_router
 from app.api.products import router as products_router
 from app.api.orders import router as orders_router
 from app.api.production import router as production_router
+from app.api.financial import router as financial_router
 
 app = FastAPI()
 app.include_router(auth_router)
@@ -14,3 +15,4 @@ app.include_router(partners_router)
 app.include_router(products_router)
 app.include_router(orders_router)
 app.include_router(production_router)
+app.include_router(financial_router)

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -24,6 +24,9 @@ class Order(Base):
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     __table_args__ = (
-        CheckConstraint("status IN ('TEKLIF','SIPARIS','URETIMDE')", name="ck_orders_status"),
+        CheckConstraint(
+            "status IN ('TEKLIF','SIPARIS','URETIMDE','TESLIM EDILDI')",
+            name="ck_orders_status",
+        ),
     )
 

--- a/backend/app/schemas/financial.py
+++ b/backend/app/schemas/financial.py
@@ -1,0 +1,64 @@
+from decimal import Decimal
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+# Account schemas
+class AccountCreate(BaseModel):
+    name: str
+
+
+class AccountUpdate(BaseModel):
+    name: str | None = None
+
+
+class AccountPublic(BaseModel):
+    id: UUID
+    organization_id: UUID
+    name: str
+    current_balance: Decimal
+
+    class Config:
+        orm_mode = True
+
+
+# Financial transaction schemas
+TransactionDirection = Literal["IN", "OUT"]
+
+
+class FinancialTransactionCreate(BaseModel):
+    account_id: UUID
+    partner_id: UUID | None = None
+    order_id: UUID | None = None
+    purchase_order_id: UUID | None = None
+    direction: TransactionDirection
+    amount: Decimal
+    description: str | None = None
+
+
+class FinancialTransactionUpdate(BaseModel):
+    partner_id: UUID | None = None
+    order_id: UUID | None = None
+    purchase_order_id: UUID | None = None
+    direction: TransactionDirection | None = None
+    amount: Decimal | None = None
+    description: str | None = None
+
+
+class FinancialTransactionPublic(BaseModel):
+    id: UUID
+    organization_id: UUID
+    account_id: UUID
+    partner_id: UUID | None
+    order_id: UUID | None
+    purchase_order_id: UUID | None
+    direction: TransactionDirection
+    amount: Decimal
+    transaction_date: datetime
+    description: str | None
+
+    class Config:
+        orm_mode = True

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from .order_item import OrderItemCreate, OrderItemUpdate, OrderItemPublic
 
-OrderStatus = Literal["TEKLIF", "SIPARIS", "URETIMDE"]
+OrderStatus = Literal["TEKLIF", "SIPARIS", "URETIMDE", "TESLIM EDILDI"]
 
 
 class OrderCreate(BaseModel):

--- a/backend/app/services/financial_service.py
+++ b/backend/app/services/financial_service.py
@@ -1,0 +1,181 @@
+"""Service layer for financial operations."""
+
+import uuid
+from decimal import Decimal
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models.account import Account
+from app.models.financial_transaction import FinancialTransaction
+from app.models.order import Order
+from app.schemas.financial import (
+    AccountCreate,
+    AccountUpdate,
+    FinancialTransactionCreate,
+    FinancialTransactionUpdate,
+)
+
+DEFAULT_ORGANIZATION_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# Account operations
+# ---------------------------------------------------------------------------
+
+def create_account(db: Session, account_in: AccountCreate) -> Account:
+    account = Account(
+        organization_id=DEFAULT_ORGANIZATION_ID,
+        name=account_in.name,
+    )
+    db.add(account)
+    db.commit()
+    db.refresh(account)
+    return account
+
+
+def get_account(db: Session, account_id: UUID) -> Optional[Account]:
+    return db.query(Account).filter(Account.id == account_id).first()
+
+
+def get_accounts(db: Session, page: int = 1, page_size: int = 10) -> List[Account]:
+    return db.query(Account).offset((page - 1) * page_size).limit(page_size).all()
+
+
+def update_account(db: Session, account_id: UUID, account_in: AccountUpdate) -> Optional[Account]:
+    account = get_account(db, account_id)
+    if not account:
+        return None
+    for field, value in account_in.dict(exclude_unset=True).items():
+        setattr(account, field, value)
+    db.commit()
+    db.refresh(account)
+    return account
+
+
+def delete_account(db: Session, account_id: UUID) -> bool:
+    account = get_account(db, account_id)
+    if not account:
+        return False
+    db.delete(account)
+    db.commit()
+    return True
+
+
+def get_account_balance(db: Session, account_id: UUID) -> Optional[Decimal]:
+    account = get_account(db, account_id)
+    if not account:
+        return None
+    return Decimal(account.current_balance)
+
+
+# ---------------------------------------------------------------------------
+# Financial transaction operations
+# ---------------------------------------------------------------------------
+
+def _apply_transaction_to_account(account: Account, direction: str, amount: Decimal) -> None:
+    if direction == "IN":
+        account.current_balance = Decimal(account.current_balance) + amount
+    else:
+        account.current_balance = Decimal(account.current_balance) - amount
+
+
+def create_transaction(
+    db: Session, transaction_in: FinancialTransactionCreate
+) -> FinancialTransaction:
+    account = get_account(db, transaction_in.account_id)
+    if not account:
+        raise ValueError("Account not found")
+    transaction = FinancialTransaction(
+        organization_id=DEFAULT_ORGANIZATION_ID,
+        account_id=transaction_in.account_id,
+        partner_id=transaction_in.partner_id,
+        order_id=transaction_in.order_id,
+        purchase_order_id=transaction_in.purchase_order_id,
+        direction=transaction_in.direction,
+        amount=transaction_in.amount,
+        description=transaction_in.description,
+    )
+    db.add(transaction)
+    _apply_transaction_to_account(account, transaction.direction, transaction.amount)
+    db.commit()
+    db.refresh(transaction)
+    return transaction
+
+
+def get_transaction(db: Session, transaction_id: UUID) -> Optional[FinancialTransaction]:
+    return db.query(FinancialTransaction).filter(FinancialTransaction.id == transaction_id).first()
+
+
+def list_transactions(
+    db: Session,
+    page: int = 1,
+    page_size: int = 10,
+    account_id: UUID | None = None,
+    direction: str | None = None,
+) -> List[FinancialTransaction]:
+    query = db.query(FinancialTransaction)
+    if account_id:
+        query = query.filter(FinancialTransaction.account_id == account_id)
+    if direction:
+        query = query.filter(FinancialTransaction.direction == direction)
+    return query.offset((page - 1) * page_size).limit(page_size).all()
+
+
+def update_transaction(
+    db: Session, transaction_id: UUID, transaction_in: FinancialTransactionUpdate
+) -> Optional[FinancialTransaction]:
+    transaction = get_transaction(db, transaction_id)
+    if not transaction:
+        return None
+    # Reverse old effect on account
+    account = get_account(db, transaction.account_id)
+    _apply_transaction_to_account(account, "OUT" if transaction.direction == "IN" else "IN", transaction.amount)
+    for field, value in transaction_in.dict(exclude_unset=True).items():
+        setattr(transaction, field, value)
+    # Apply new effect
+    _apply_transaction_to_account(account, transaction.direction, transaction.amount)
+    db.commit()
+    db.refresh(transaction)
+    return transaction
+
+
+def delete_transaction(db: Session, transaction_id: UUID) -> bool:
+    transaction = get_transaction(db, transaction_id)
+    if not transaction:
+        return False
+    account = get_account(db, transaction.account_id)
+    _apply_transaction_to_account(account, "OUT" if transaction.direction == "IN" else "IN", transaction.amount)
+    db.delete(transaction)
+    db.commit()
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Business operations
+# ---------------------------------------------------------------------------
+
+def create_payment_for_order(
+    db: Session,
+    order_id: UUID,
+    account_id: UUID,
+    amount: Decimal,
+    description: str | None = None,
+) -> FinancialTransaction:
+    order = db.query(Order).filter(Order.id == order_id).first()
+    if not order:
+        raise ValueError("Order not found")
+    transaction_in = FinancialTransactionCreate(
+        account_id=account_id,
+        order_id=order_id,
+        direction="IN",
+        amount=amount,
+        description=description,
+    )
+    transaction = create_transaction(db, transaction_in)
+    # Update order status
+    order.status = "TESLIM EDILDI"
+    db.commit()
+    db.refresh(order)
+    return transaction


### PR DESCRIPTION
## Summary
- add schemas, services, and API endpoints for accounts and financial transactions
- support order payments updating balances and order status
- wire financial router into main app and extend order status enum

## Testing
- `pytest`
- `python -m py_compile backend/app/schemas/financial.py backend/app/services/financial_service.py backend/app/api/financial.py backend/app/schemas/order.py backend/app/models/order.py backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad9614a4a0832dbf6beb9df60be490