### PR TITLE
Expose dashboard summaries and enable CORS

### DIFF
--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -1,12 +1,26 @@
-﻿# app/api/dashboard.py
+"""Dashboard summary endpoints."""
+
 from fastapi import APIRouter
 
-router = APIRouter()
+
+router = APIRouter(prefix="/api", tags=["dashboard"])
+
 
 @router.get("/finance/summary")
 def finance_summary():
-    return {"revenue": 125000, "expense": 83000, "profit": 42000, "currency": "TRY"}
+    return {
+        "revenue": 125000,
+        "expense": 83000,
+        "profit": 42000,
+        "currency": "TRY",
+    }
+
 
 @router.get("/operations/summary")
 def operations_summary():
-    return {"orders_pending": 7, "orders_in_progress": 12, "orders_completed_today": 5, "stations_active": 2}
+    return {
+        "orders_pending": 7,
+        "orders_in_progress": 12,
+        "orders_completed_today": 5,
+        "stations_active": 2,
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 """FastAPI application entry point."""
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.auth import router as auth_router
 from app.api.partners import router as partners_router
@@ -8,11 +9,24 @@ from app.api.products import router as products_router
 from app.api.orders import router as orders_router
 from app.api.production import router as production_router
 from app.api.financial import router as financial_router
+from app.api.dashboard import router as dashboard_router
 
 app = FastAPI()
+
+origins = ["http://localhost:3000", "http://127.0.0.1:3000"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(auth_router)
 app.include_router(partners_router)
 app.include_router(products_router)
 app.include_router(orders_router)
 app.include_router(production_router)
 app.include_router(financial_router)
+app.include_router(dashboard_router)

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,7 +1,7 @@
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000/api';
 
 export async function getFinancialSummary() {
-  const res = await fetch(`${API_BASE}/products/`);
+  const res = await fetch(`${API_BASE}/finance/summary`);
   if (!res.ok) {
     throw new Error('Failed to fetch financial summary');
   }


### PR DESCRIPTION
## Summary
- add dashboard router with finance and operations summaries
- enable CORS for local frontend origins
- fix frontend API base URL and endpoints

## Testing
- `python -m py_compile backend/app/api/dashboard.py backend/app/main.py`
- `python -m pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc68f4b90832db8a729c16140a7bb